### PR TITLE
Restrict user access to views

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -1,11 +1,10 @@
 <?php namespace Thoughtco\KitchenDisplay;
 
 use AdminAuth;
+use Admin\Facades\AdminLocation;
 use Admin\Widgets\Form;
 use DB;
 use Event;
-use Illuminate\Support\Arr;
-use Admin\Facades\AdminLocation;
 use System\Classes\BaseExtension;
 use Thoughtco\KitchenDisplay\Models\Views;
 
@@ -34,19 +33,30 @@ class Extension extends BaseExtension
 		});
 
         Event::listen('admin.list.extendQuery', function ($listWidget, $query) {
-            if ($listWidget->getController() instanceof \Thoughtco\KitchenDisplay\Controllers\Views){
+
+            if (AdminAuth::isSuperUser())
+                return;
+
+            if ($listWidget->getController() instanceof \Thoughtco\KitchenDisplay\Controllers\Views) {
+
                 // build list of views the user is allowed to access by location
-		        $viewList = [];
-		        Views::where(['is_enabled' => true])
-				->each(function($view) use (&$viewList) {
-                        //if (AdminLocation::getId() === NULL || AdminLocation::getId() == $view->locations) {
-                            $limitedUsers = Arr::get($view->display, 'users_limit', []);
-							if (in_array(AdminAuth::getId(), $limitedUsers)) {
-				        		$viewList[] = $view->id;
-							}
-				        //}
-		        });
-                $query->whereIn('id', $viewList);
+		        $viewList = Views::where(['is_enabled' => true])
+				->map(function($view) {
+                    if (AdminLocation::getId() === NULL || in_array(AdminLocation::getId(), $view->locations)) {
+
+                        $limitedUsers = array_get($view->display, 'users_limit', []);
+
+                        // if users is blank or in array
+						if (!count($limitedUsers) OR in_array(AdminAuth::getId(), $limitedUsers))
+			        		return $view->id;
+
+			        }
+
+                    return;
+		        })
+                ->whereNotNull();
+
+                $query->whereIn('id', $viewList->toArray());
 			}
         });
     }

--- a/Extension.php
+++ b/Extension.php
@@ -6,7 +6,7 @@ use Admin\Widgets\Form;
 use DB;
 use Event;
 use System\Classes\BaseExtension;
-use Thoughtco\KitchenDisplay\Models\Views;
+use Thoughtco\KitchenDisplay\Models\Views as KitchenViews;;
 
 /**
  * Extension Information File
@@ -40,7 +40,8 @@ class Extension extends BaseExtension
             if ($listWidget->getController() instanceof \Thoughtco\KitchenDisplay\Controllers\Views) {
 
                 // build list of views the user is allowed to access by location
-		        $viewList = Views::where(['is_enabled' => true])
+		        $viewList = KitchenViews::where(['is_enabled' => true])
+                ->get()
 				->map(function($view) {
                     if (AdminLocation::getId() === NULL || in_array(AdminLocation::getId(), $view->locations)) {
 

--- a/Extension.php
+++ b/Extension.php
@@ -6,7 +6,7 @@ use Admin\Widgets\Form;
 use DB;
 use Event;
 use System\Classes\BaseExtension;
-use Thoughtco\KitchenDisplay\Models\Views as KitchenViews;;
+use Thoughtco\KitchenDisplay\Models\Views as KitchenViews;
 
 /**
  * Extension Information File

--- a/controllers/Summary.php
+++ b/controllers/Summary.php
@@ -2,6 +2,7 @@
 
 namespace Thoughtco\KitchenDisplay\Controllers;
 
+use AdminAuth;
 use AdminMenu;
 use Admin\Facades\AdminLocation;
 use Admin\Models\Locations_model;
@@ -36,6 +37,18 @@ class Summary extends \Admin\Classes\AdminController
 
     public function view($route, $viewId)
     {
+
+        if (!AdminAuth::isSuperUser()) {
+            if (AdminLocation::getId() === NULL || in_array(AdminLocation::getId(), $view->locations)) {
+
+                $limitedUsers = array_get($view->display, 'users_limit', []);
+
+				if (count($limitedUsers) AND !in_array(AdminAuth::getId(), $limitedUsers))
+                    throw new ApplicationException('Permission denied');
+
+            }
+        }
+
 		if ($viewSettings = KitchenViews::where([
 			['id', $viewId],
 			['is_enabled', 1],

--- a/controllers/Summary.php
+++ b/controllers/Summary.php
@@ -37,11 +37,15 @@ class Summary extends \Admin\Classes\AdminController
 
     public function view($route, $viewId)
     {
+        $viewSettings = KitchenViews::where([
+			['id', $viewId],
+			['is_enabled', 1],
+		])->first();
 
         if (!AdminAuth::isSuperUser()) {
-            if (AdminLocation::getId() === NULL || in_array(AdminLocation::getId(), $view->locations)) {
+            if (AdminLocation::getId() === NULL || in_array(AdminLocation::getId(), $viewSettings->locations)) {
 
-                $limitedUsers = array_get($view->display, 'users_limit', []);
+                $limitedUsers = array_get($viewSettings->display, 'users_limit', []);
 
 				if (count($limitedUsers) AND !in_array(AdminAuth::getId(), $limitedUsers))
                     throw new ApplicationException('Permission denied');
@@ -49,10 +53,7 @@ class Summary extends \Admin\Classes\AdminController
             }
         }
 
-		if ($viewSettings = KitchenViews::where([
-			['id', $viewId],
-			['is_enabled', 1],
-		])->first())
+		if ($viewSettings)
 		{
 
         	Template::setTitle($viewSettings->name);
@@ -106,7 +107,7 @@ class Summary extends \Admin\Classes\AdminController
             array_filter($statuses);
             $statuses = array_values($statuses);
 
-            if (!count($statuses))
+            if (count($statuses))
 			{
 				$statuses[] = $viewSettings->order_status;
 				if ($viewSettings->display['button1_enable'])

--- a/controllers/Views.php
+++ b/controllers/Views.php
@@ -65,7 +65,7 @@ class Views extends \Admin\Classes\AdminController
 
     public function create()
     {
-        if (!AdminAuth::user()->hasPermission('Thoughtco.Printer.Manage'))
+        if (!AdminAuth::user()->hasPermission('Thoughtco.KitchenDisplay.Manage'))
             throw new ApplicationException('Permission denied');
 
         return parent::create();
@@ -73,7 +73,7 @@ class Views extends \Admin\Classes\AdminController
 
     public function edit($a, $b)
     {
-        if (!AdminAuth::user()->hasPermission('Thoughtco.Printer.Manage'))
+        if (!AdminAuth::user()->hasPermission('Thoughtco.KitchenDisplay.Manage'))
             throw new ApplicationException('Permission denied');
 
         return parent::edit($a, $b);

--- a/language/en/default.php
+++ b/language/en/default.php
@@ -14,6 +14,7 @@ return [
     'column_status' => 'Status',
 
     'comment_ordersforXhours' => '0 means no limits',
+    'comment_limitUsers' => 'None selected means no restrictions',
 
     'btn_view' => 'View',
     'btn_prep' => 'Prep',
@@ -30,6 +31,7 @@ return [
     'label_ordercount' => 'Number of orders to show',
     'label_refreshinterval' => 'Refresh interval in seconds',
     'label_ordersforXhours' => 'Limit to the next X hours of orders',
+    'label_limitUsers' => 'Restrict access to selected users',
 
     'label_button1_enabled' => 'Button 1 enabled',
     'label_button1_text' => 'Button 1 text',

--- a/models/Views.php
+++ b/models/Views.php
@@ -44,9 +44,6 @@ class Views extends Model
 
         if (!Request::input('View.categories'))
             $this->categories = [];
-
-        if (!Request::input('View.users_limit'))
-            $this->users_limit = [];
     }
 
     public static function getCardLineOptions($line)

--- a/models/Views.php
+++ b/models/Views.php
@@ -44,6 +44,9 @@ class Views extends Model
 
         if (!Request::input('View.categories'))
             $this->categories = [];
+
+        if (!Request::input('View.users_limit'))
+            $this->users_limit = [];
     }
 
     public static function getCardLineOptions($line)

--- a/models/config/views.php
+++ b/models/config/views.php
@@ -148,6 +148,16 @@ return [
 	                'default' => 24,
 	                'cssClass' => 'flex-width',
 	            ],
+                'display[users_limit]' => [
+	                'tab' => 'lang:thoughtco.kitchendisplay::default.tab_general',
+	                'label' => 'lang:thoughtco.kitchendisplay::default.label_limitUsers',
+                    'comment' => 'lang:thoughtco.kitchendisplay::default.comment_limitUsers',
+	                'type' => 'selectlist',
+	                'default' => '',
+                    'cssClass' => 'flex-width',
+		            'options' => ['\Admin\Models\Staffs_model', 'getDropdownOptions'],
+	                'span' => 'right',
+				],
 	            'display[button1_enable]' => [
 	                'tab' => 'lang:thoughtco.kitchendisplay::default.tab_buttons',
 		            'label' => 'thoughtco.kitchendisplay::default.label_button1_status',


### PR DESCRIPTION
First attempt. @ryanmitchell if you can give some hints/work on some the following points:

- location restriction needs some tuning (Commented out them for now)
- super admin should see always all views
- actually with no permissions involved in core List for row columns as in latest october cms we are doing just a pre-made filters users will still be able to access direct links to view

Let me know